### PR TITLE
having elements go back to the main section, until we have a landing …

### DIFF
--- a/source/elements/index.html.md
+++ b/source/elements/index.html.md
@@ -8,7 +8,7 @@ language_tabs: # must be one of https://git.io/vQNgJ
 toc_footers:
 
 other_docs:
-  - <a href="/api-reference">API Reference</a>
+  - <a href="/">API Reference</a>
 
 intro_quick_links:
   - elements/quick_links


### PR DESCRIPTION
…page

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

<!-- Describe your changes in detail -->
## Description

- sending link on Elements back to main page until new page is ready

<!-- Describe impact to business or business use case -->
## Business Impact

- N/A

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

<!-- Ensure that all related documentation on notion is updated -->
## Documentation


## Reviewer Checklist

- [ ] Descrption of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change

