### PR TITLE
chore: Update route for get reaction by id to /reactions/:id

### DIFF
--- a/source/includes/api-reference/_atomic_banks.md
+++ b/source/includes/api-reference/_atomic_banks.md
@@ -468,7 +468,7 @@ Returns a [token](#token-object) with type of `bank:reaction` if the Atomic Bank
 > Request
 
 ```shell
-curl "https://api.basistheory.com/atomic/banks/1485efb9-6b1f-4248-a5d1-cf9b3907164c/reaction/6c12a05d-99e3-4454-bdb0-2e6ff88ec5b0" \
+curl "https://api.basistheory.com/atomic/banks/1485efb9-6b1f-4248-a5d1-cf9b3907164c/reactions/6c12a05d-99e3-4454-bdb0-2e6ff88ec5b0" \
   -H "X-API-KEY: key_N88mVGsp3sCXkykyN2EFED" \
   -X "GET"
 ```
@@ -493,7 +493,7 @@ var reactionToken = await client.GetReactionByIdAsync(
 
 <span class="http-method get">
   <span class="box-method">GET</span>
-  `https://api.basistheory.com/atomic/banks/{atomicBankId}/reaction/{reactionTokenId}`
+  `https://api.basistheory.com/atomic/banks/{atomicBankId}/reactions/{reactionTokenId}`
 </span>
 
 Get an Atomic Bank reaction token by ID in the Tenant.

--- a/source/includes/api-reference/_atomic_cards.md
+++ b/source/includes/api-reference/_atomic_cards.md
@@ -507,7 +507,7 @@ Returns a [token](#token-object) with type of `card:reaction` if the Atomic Card
 > Request
 
 ```shell
-curl "https://api.basistheory.com/atomic/cards/c1e565009-1984-4638-8fca-dce8a82cc2af/reaction/6c12a05d-99e3-4454-bdb0-2e6ff88ec5b0" \
+curl "https://api.basistheory.com/atomic/cards/c1e565009-1984-4638-8fca-dce8a82cc2af/reactions/6c12a05d-99e3-4454-bdb0-2e6ff88ec5b0" \
   -H "X-API-KEY: key_N88mVGsp3sCXkykyN2EFED" \
   -X "GET"
 ```
@@ -532,7 +532,7 @@ var reactionToken = await client.GetReactionByIdAsync(
 
 <span class="http-method get">
   <span class="box-method">GET</span>
-  `https://api.basistheory.com/atomic/cards/{atomicCardId}/reaction/{reactionTokenId}`
+  `https://api.basistheory.com/atomic/cards/{atomicCardId}/reactions/{reactionTokenId}`
 </span>
 
 Get an Atomic Card reaction token by ID in the Tenant.


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- The url was incorrectly documented as GET `atomic/(card|bank)/reaction/:id`, changed to GET `atomic/(card|bank)/reactions/:id`,

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
