### PR TITLE
ENG-1726 - Add disabled attribute to text element docs

### DIFF
--- a/source/includes/elements/_element_style.md
+++ b/source/includes/elements/_element_style.md
@@ -15,13 +15,16 @@ var cardElement = BasisTheory.elements.create('card', {
       "::placeholder": {
         color: "#6b7294"
       },
-      invalid: {
-        color: "#ffc7ee"
+      ":disabled": {
+        backgroundColor: "#f0f0f4"
       },
-      complete: {
-        color: "#1ad1db"
-      }
-    }
+    },
+    invalid: {
+      color: "#ffc7ee"
+    },
+    complete: {
+      color: "#1ad1db"
+    }    
   }
 })
 ```
@@ -40,6 +43,7 @@ You can customize the following pseudo-classes and pseudo-elements inside each v
 
 - `:hover`
 - `:focus`
+- `:disabled`  
 - `::placeholder`
 - `::selection`
 

--- a/source/includes/elements/_elements_instance.md
+++ b/source/includes/elements/_elements_instance.md
@@ -37,6 +37,7 @@ Attribute     | Required | Type                 | Eligible Elements             
 `transform`   | false    | *ElementTransform*   | [TextElement](#element-types-text-element) | `RegExp` object or [array](#element-transform) used to modify user input before sending input to any [services](#elements-services)
 `placeholder` | false    | *string*             | [TextElement](#element-types-text-element) | String used to customize the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input#attr-placeholder) of the input
 `aria-label`  | false    | *string*             | [TextElement](#element-types-text-element) | String used to customize the [aria-label attribute](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) of the input
+`disabled`    | false    | *boolean*      | [TextElement](#element-types-text-element) | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input
 
 ## Mount Element
 
@@ -85,7 +86,7 @@ Attribute     | Required | Type                 | Eligible elements             
 `transform`   | false    | *ElementTransform*   | [TextElement](#element-types-text-element)  | `RegExp` object or [array](#element-transform) used to modify user input before sending input to any [services](#elements-services)
 `placeholder` | false    | *string*             | [TextElement](#element-types-text-element)  | String used to customize the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input#attr-placeholder) of the input
 `aria-label`  | false    | *string*             | [TextElement](#element-types-text-element)  | String used to customize the [aria-label attribute](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) of the input
-
+`disabled`    | false    | *boolean*      | [TextElement](#element-types-text-element) | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input
 
 ## Clear Element
 

--- a/source/includes/elements/_elements_instance.md
+++ b/source/includes/elements/_elements_instance.md
@@ -32,12 +32,12 @@ CreateElementOptions provide a quick way to customize an Element before mounting
 Attribute     | Required | Type                 | Eligible Elements                          | Description
 ------------- | -------- | -------------------- | ------------------------------------------ | -----------
 `style`       | false    | *ElementStyle*       | All                                        | [Object](#element-style) used to customize the element appearance
+`disabled`    | false    | *boolean*            | All                                        | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input(s)
 `targetId`    | true     | *string*             | [TextElement](#element-types-text-element) | String used to identify your element
 `mask`        | false    | *ElementMask*        | [TextElement](#element-types-text-element) | [Array](#element-mask) used to restrict and fill user input using regex and static strings
 `transform`   | false    | *ElementTransform*   | [TextElement](#element-types-text-element) | `RegExp` object or [array](#element-transform) used to modify user input before sending input to any [services](#elements-services)
 `placeholder` | false    | *string*             | [TextElement](#element-types-text-element) | String used to customize the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input#attr-placeholder) of the input
 `aria-label`  | false    | *string*             | [TextElement](#element-types-text-element) | String used to customize the [aria-label attribute](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) of the input
-`disabled`    | false    | *boolean*      | [TextElement](#element-types-text-element) | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input
 
 ## Mount Element
 
@@ -83,10 +83,10 @@ UpdateElementOptions provide a quick way to change an existing (mounted) Element
 Attribute     | Required | Type                 | Eligible elements                           | Description
 ------------- | -------- | -------------------- | ------------------------------------------- | -----------
 `style`       | false    | *ElementStyle*       | All                                         | [Object](#element-style) used to customize the element appearance
+`disabled`    | false    | *boolean*            | All                                         | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input(s)
 `transform`   | false    | *ElementTransform*   | [TextElement](#element-types-text-element)  | `RegExp` object or [array](#element-transform) used to modify user input before sending input to any [services](#elements-services)
 `placeholder` | false    | *string*             | [TextElement](#element-types-text-element)  | String used to customize the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input#attr-placeholder) of the input
 `aria-label`  | false    | *string*             | [TextElement](#element-types-text-element)  | String used to customize the [aria-label attribute](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) of the input
-`disabled`    | false    | *boolean*      | [TextElement](#element-types-text-element) | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input
 
 ## Clear Element
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds documentation for the `disabled` attribute for the TextElement
 
<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/9054729/143459940-1af68af2-0501-465f-80d1-c158083d9019.png)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
