### PR TITLE
ENG-1915 - Add docs for password option for elements

### DIFF
--- a/source/includes/elements/_elements_instance.md
+++ b/source/includes/elements/_elements_instance.md
@@ -34,6 +34,11 @@ Attribute     | Required | Type                 | Eligible Elements             
 `transform`   | false    | *ElementTransform*   | [TextElement](#element-types-text-element) | `RegExp` object or [array](#element-transform) used to modify user input before sending input to any [services](#elements-services)
 `placeholder` | false    | *string*             | [TextElement](#element-types-text-element) | String used to customize the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input#attr-placeholder) of the input
 `aria-label`  | false    | *string*             | [TextElement](#element-types-text-element) | String used to customize the [aria-label attribute](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) of the input
+`password`    | false    | *boolean*            | [TextElement](#element-types-text-element) | Boolean used to set the text element input type as [password](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password)
+
+<aside class="warning">
+  <span>The <code>mask</code> option cannot be used when the <code>password</code> option is set as <code>true</code>.</span>
+</aside>
 
 ## Mount Element
 
@@ -83,6 +88,11 @@ Attribute     | Required | Type                 | Eligible elements             
 `transform`   | false    | *ElementTransform*   | [TextElement](#element-types-text-element)  | `RegExp` object or [array](#element-transform) used to modify user input before sending input to any [services](#elements-services)
 `placeholder` | false    | *string*             | [TextElement](#element-types-text-element)  | String used to customize the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input#attr-placeholder) of the input
 `aria-label`  | false    | *string*             | [TextElement](#element-types-text-element)  | String used to customize the [aria-label attribute](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) of the input
+`password`    | false    | *boolean*            | [TextElement](#element-types-text-element) | Boolean used to set the text element input type as [password](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password)
+
+<aside class="warning">
+  <span>The <code>password</code> option cannot be set as <code>true</code> if the text element has a <code>mask</code> set.</span>
+</aside>
 
 ## Clear Element
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description
- Adds docs for `password` option for `TextElement`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):
![Screen Shot 2022-01-07 at 18 33 20](https://user-images.githubusercontent.com/9054729/148610774-e204290f-c4cd-4a91-87d3-845f56d0eab1.png)

![Screen Shot 2022-01-07 at 18 33 33](https://user-images.githubusercontent.com/9054729/148610808-eb39bb2b-16b9-4215-95a5-4fbb72d2a88e.png)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
