### PR TITLE
feat: document cardBrand onChange event property

### DIFF
--- a/source/includes/elements/react/_card_element.md
+++ b/source/includes/elements/react/_card_element.md
@@ -74,3 +74,7 @@ The CardElement's `onChange` event will return the brand of the credit card. See
 | UnionPay         | `unionpay`         |
 | Visa             | `visa`             |
 | Unknown          | `unknown`          |
+
+<aside class="notice">
+  <span>If you don't see the card brand you're looking for, please <a href="mailto:support@basistheory.com?subject=CardElement request card brand" target="_blank">contact us</a>!</span>
+</aside>

--- a/source/includes/elements/react/_card_element.md
+++ b/source/includes/elements/react/_card_element.md
@@ -43,14 +43,34 @@ const MyComponent = () => {
 `CardElement` <a href="https://reactjs.org/docs/components-and-props.html" target="_blank">component</a> features a full credit card form, wrapping the [card element type](#element-types-card-element) functionality and taking care of the React lifecycle.
 
 
-Property    | Required | Type                | Updatable | Description
------------ | -------- | ------------------- | --------- | -----------
-`id`        | true     | *string*            | false     | String identifier used to retrieve the Element instance for tokenization.
-`bt`        | false    | *BasisTheoryReact*  | false     | [Instance](#basistheoryreact) used by the Element. <br><i>Note: this is not required because Elements are capable of consuming the instance from Context. See [`BasisTheoryProvider`](#basistheoryprovider).</i>
-`style`     | false    | *ElementStyle*      | true      | [Object](#element-style) used to customize the element appearance
-`disabled`  | false    | *boolean*           | true      | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input(s)
-`onReady`   | false    | *function*          | true      | Event Listener. See [On Ready](#element-events-on-ready)
-`onChange`  | false    | *function*          | true      | Event Listener. See [On Change](#element-events-on-change)
-`onFocus`   | false    | *function*          | true      | Event Listener. See [On Focus](#element-events-on-focus)
-`onBlur`    | false    | *function*          | true      | Event Listener. See [On Blur](#element-events-on-blur)
-`onKeyDown` | false    | *function*          | true      | Event Listener. See [On Keydown](#element-events-on-keydown)
+| Property    | Required | Type               | Updatable | Description                                                                                                                                                                                                      |
+|-------------|----------|--------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`        | true     | *string*           | false     | String identifier used to retrieve the Element instance for tokenization.                                                                                                                                        |
+| `bt`        | false    | *BasisTheoryReact* | false     | [Instance](#basistheoryreact) used by the Element. <br><i>Note: this is not required because Elements are capable of consuming the instance from Context. See [`BasisTheoryProvider`](#basistheoryprovider).</i> |
+| `style`     | false    | *ElementStyle*     | true      | [Object](#element-style) used to customize the element appearance                                                                                                                                                |
+| `disabled`  | false    | *boolean*          | true      | Boolean used to set the [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) of the input(s)                                                                              |
+| `onReady`   | false    | *function*         | true      | Event Listener. See [On Ready](#element-events-on-ready)                                                                                                                                                         |
+| `onChange`  | false    | *function*         | true      | Event Listener. See [On Change](#element-events-on-change)                                                                                                                                                       |
+| `onFocus`   | false    | *function*         | true      | Event Listener. See [On Focus](#element-events-on-focus)                                                                                                                                                         |
+| `onBlur`    | false    | *function*         | true      | Event Listener. See [On Blur](#element-events-on-blur)                                                                                                                                                           |
+| `onKeyDown` | false    | *function*         | true      | Event Listener. See [On Keydown](#element-events-on-keydown)                                                                                                                                                     |
+
+## Card Brands
+
+The CardElement's `onChange` event will return the brand of the credit card. See the following list for possible values:
+
+| Brand            | Value              |
+|------------------|--------------------|
+| American Express | `american-express` |
+| Diners Club      | `diners-club`      |
+| Discover         | `discover`         |
+| Elo              | `elo`              |
+| Hiper            | `hiper`            |
+| HiperCard        | `hipercard`        |
+| JCB              | `jcb`              |
+| Maestro          | `maestro`          |
+| Mastercard       | `mastercard`       |
+| MIR              | `mir`              |
+| UnionPay         | `unionpay`         |
+| Visa             | `visa`             |
+| Unknown          | `unknown`          |

--- a/source/includes/elements/vanilla/_element_events.md
+++ b/source/includes/elements/vanilla/_element_events.md
@@ -43,10 +43,10 @@ cardElement.on('change', (changeEvent) => {
 
 This event is triggered whenever element's value(s) change. For example, if the user types data that doesn't change the state of a field between valid/invalid or empty/filled, you shouldn't expect the event to trigger.
 
-Parameter | Required | Type       | Description
---------- | -------- | ---------- | -----------
-`event`   | true     | *"change"* | The event type to listen to.
-`handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [ChangeEvent](#element-events-on-change-changeevent).
+| Parameter | Required | Type       | Description                                                                                                              |
+|-----------|----------|------------|--------------------------------------------------------------------------------------------------------------------------|
+| `event`   | true     | *"change"* | The event type to listen to.                                                                                             |
+| `handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [ChangeEvent](#element-events-on-change-changeevent). |
 
 ### ChangeEvent
 
@@ -57,15 +57,17 @@ Parameter | Required | Type       | Description
   "errors": [
     {...},
     {...}
-  ]
+  ],
+  "cardBrand": "american-express"
 }
 ```
 
-Attribute  | Type       | Description
----------- | ---------- | -----------
-`complete` | *boolean*  | If the element value is well-formed and is ready to be submitted.
-`empty`    | *boolean*  | Whether the element is empty. Multi-input Elements will be `empty` only if all inputs are.
-`errors`   | *array*    | Array of [FieldError](#element-events-on-change-fielderror).
+| Attribute   | Type      | Eligible Elements           | Description                                                                                |
+|-------------|-----------|-----------------------------|--------------------------------------------------------------------------------------------|
+| `complete`  | *boolean* | All                         | If the element value is well-formed and is ready to be submitted.                          |
+| `empty`     | *boolean* | All                         | Whether the element is empty. Multi-input Elements will be `empty` only if all inputs are. |
+| `errors`    | *array*   | All                         | Array of [FieldError](#element-events-on-change-fielderror).                               |
+| `cardBrand` | *string*  | [CardElement](#cardelement) | (Optional) The credit card brand (e.g. `'american-express'`, `'visa'`, `'unknown'`).       |
 
 ### FieldError
 
@@ -76,10 +78,10 @@ Attribute  | Type       | Description
 }
 ```
 
-Attribute  | Type       | Description
----------- | ---------- | -----------
-`targetId` | *string*                        | Input id that triggered the error. Values vary per [element type](#element-types).
-`type`     | *"invalid"* or *"incomplete"*   | Type of the error.
+| Attribute  | Type                          | Description                                                                        |
+|------------|-------------------------------|------------------------------------------------------------------------------------|
+| `targetId` | *string*                      | Input id that triggered the error. Values vary per [element type](#element-types). |
+| `type`     | *"invalid"* or *"incomplete"* | Type of the error.                                                                 |
 
 ## On Focus
 
@@ -91,10 +93,10 @@ cardElement.on('focus', (focusEvent) => {
 
 Triggered when an element input is focused.
 
-Parameter | Required | Type       | Description
---------- | -------- | ---------- | -----------
-`event`   | true     | *"focus"* | The event type to listen to.
-`handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [FocusEvent](#element-events-on-focus-focusevent).
+| Parameter | Required | Type       | Description                                                                                                           |
+|-----------|----------|------------|-----------------------------------------------------------------------------------------------------------------------|
+| `event`   | true     | *"focus"*  | The event type to listen to.                                                                                          |
+| `handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [FocusEvent](#element-events-on-focus-focusevent). |
 
 ### FocusEvent
 
@@ -104,9 +106,9 @@ Parameter | Required | Type       | Description
 }
 ```
 
-Attribute  | Type       | Description
----------- | ---------- | -----------
-`targetId`       | *string*   | Input id that triggered the event. Values vary per [element type](#element-types).
+| Attribute  | Type     | Description                                                                        |
+|------------|----------|------------------------------------------------------------------------------------|
+| `targetId` | *string* | Input id that triggered the event. Values vary per [element type](#element-types). |
 
 ## On Blur
 
@@ -118,10 +120,10 @@ cardElement.on('blur', (blurEvent) => {
 
 Triggered when an element input focus is lost.
 
-Parameter | Required | Type       | Description
---------- | -------- | ---------- | -----------
-`event`   | true     | *"blur"* | The event type to listen to.
-`handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [BlurEvent](#element-events-on-blur-blurevent).
+| Parameter | Required | Type       | Description                                                                                                        |
+|-----------|----------|------------|--------------------------------------------------------------------------------------------------------------------|
+| `event`   | true     | *"blur"*   | The event type to listen to.                                                                                       |
+| `handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [BlurEvent](#element-events-on-blur-blurevent). |
 
 ### BlurEvent
 
@@ -131,9 +133,9 @@ Parameter | Required | Type       | Description
 }
 ```
 
-Attribute  | Type       | Description
----------- | ---------- | -----------
-`targetId`       | *string*   | Input id that triggered the event. Values vary per [element type](#element-types).
+| Attribute  | Type     | Description                                                                        |
+|------------|----------|------------------------------------------------------------------------------------|
+| `targetId` | *string* | Input id that triggered the event. Values vary per [element type](#element-types). |
 
 ## On Keydown
 
@@ -145,10 +147,10 @@ cardElement.on('keydown', (keydownEvent) => {
 
 Triggered when user hits a special key inside an element input.
 
-Parameter | Required | Type       | Description
---------- | -------- | ---------- | -----------
-`event`   | true     | *"keydown"* | The event type to listen to.
-`handler` | true     | *function* | Callback function to be called when the event is fired. Takes in a [KeydownEvent](#element-events-on-keydown-keydownevent).
+| Parameter | Required | Type        | Description                                                                                                                 |
+|-----------|----------|-------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `event`   | true     | *"keydown"* | The event type to listen to.                                                                                                |
+| `handler` | true     | *function*  | Callback function to be called when the event is fired. Takes in a [KeydownEvent](#element-events-on-keydown-keydownevent). |
 
 ### KeydownEvent
 
@@ -163,11 +165,11 @@ Parameter | Required | Type       | Description
 }
 ```
 
-Attribute  | Type                  | Description
----------- | ----------            | -----------
-`targetId` | *string*              | Input targetId that triggered the event. Values vary per [element type](#element-types).
-`key`      | *Escape* or *Enter*   | Key pressed by the user.
-`ctrlKey`  | *boolean*             | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/ctrlKey" target="_blank">`control` key</a> was pressed when the event occurred.
-`altKey`   | *boolean*             | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/altKey" target="_blank">`alt` key</a> was pressed when the event occurred.
-`shiftKey` | *boolean*             | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/shiftKey" target="_blank">`shift` key</a> was pressed when the event occurred.
-`metaKey`  | *boolean*             | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey" target="_blank">`meta` key</a> was pressed when the event occurred.
+| Attribute  | Type                | Description                                                                                                                                                             |
+|------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `targetId` | *string*            | Input targetId that triggered the event. Values vary per [element type](#element-types).                                                                                |
+| `key`      | *Escape* or *Enter* | Key pressed by the user.                                                                                                                                                |
+| `ctrlKey`  | *boolean*           | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/ctrlKey" target="_blank">`control` key</a> was pressed when the event occurred. |
+| `altKey`   | *boolean*           | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/altKey" target="_blank">`alt` key</a> was pressed when the event occurred.      |
+| `shiftKey` | *boolean*           | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/shiftKey" target="_blank">`shift` key</a> was pressed when the event occurred.  |
+| `metaKey`  | *boolean*           | Flag indicating <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey" target="_blank">`meta` key</a> was pressed when the event occurred.    |

--- a/source/includes/elements/vanilla/_element_events.md
+++ b/source/includes/elements/vanilla/_element_events.md
@@ -62,12 +62,12 @@ This event is triggered whenever element's value(s) change. For example, if the 
 }
 ```
 
-| Attribute   | Type      | Eligible Elements           | Description                                                                                |
-|-------------|-----------|-----------------------------|--------------------------------------------------------------------------------------------|
-| `complete`  | *boolean* | All                         | If the element value is well-formed and is ready to be submitted.                          |
-| `empty`     | *boolean* | All                         | Whether the element is empty. Multi-input Elements will be `empty` only if all inputs are. |
-| `errors`    | *array*   | All                         | Array of [FieldError](#element-events-on-change-fielderror).                               |
-| `cardBrand` | *string*  | [CardElement](#cardelement) | (Optional) The credit card brand (e.g. `'american-express'`, `'visa'`, `'unknown'`).       |
+| Attribute   | Type      | Eligible Elements           | Description                                                                                                                                                                                                          |
+|-------------|-----------|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `complete`  | *boolean* | All                         | If the element value is well-formed and is ready to be submitted.                                                                                                                                                    |
+| `empty`     | *boolean* | All                         | Whether the element is empty. Multi-input Elements will be `empty` only if all inputs are.                                                                                                                           |
+| `errors`    | *array*   | All                         | Array of [FieldError](#element-events-on-change-fielderror).                                                                                                                                                         |
+| `cardBrand` | *string*  | [CardElement](#cardelement) | (Optional) The credit card brand (e.g. `'american-express'`, `'visa'`, `'unknown'`). The value is always set when using a [CardElement](#cardelement), and defaults to `'unknown'` until a card brand is recognized. |
 
 ### FieldError
 

--- a/source/includes/elements/vanilla/_element_events.md
+++ b/source/includes/elements/vanilla/_element_events.md
@@ -62,12 +62,12 @@ This event is triggered whenever element's value(s) change. For example, if the 
 }
 ```
 
-| Attribute   | Type      | Eligible Elements           | Description                                                                                                                                                                                                          |
-|-------------|-----------|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `complete`  | *boolean* | All                         | If the element value is well-formed and is ready to be submitted.                                                                                                                                                    |
-| `empty`     | *boolean* | All                         | Whether the element is empty. Multi-input Elements will be `empty` only if all inputs are.                                                                                                                           |
-| `errors`    | *array*   | All                         | Array of [FieldError](#element-events-on-change-fielderror).                                                                                                                                                         |
-| `cardBrand` | *string*  | [CardElement](#cardelement) | (Optional) The credit card brand (e.g. `'american-express'`, `'visa'`, `'unknown'`). The value is always set when using a [CardElement](#cardelement), and defaults to `'unknown'` until a card brand is recognized. |
+| Attribute   | Type      | Eligible Elements           | Description                                                                                                                                                                          |
+|-------------|-----------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `complete`  | *boolean* | All                         | If the element value is well-formed and is ready to be submitted.                                                                                                                    |
+| `empty`     | *boolean* | All                         | Whether the element is empty. Multi-input Elements will be `empty` only if all inputs are.                                                                                           |
+| `errors`    | *array*   | All                         | Array of [FieldError](#element-events-on-change-fielderror).                                                                                                                         |
+| `cardBrand` | *string*  | [CardElement](#cardelement) | (Optional) The credit card [brand](#cardelement-card-brands) (e.g. `'american-express'`, `'visa'`, `'unknown'`). The value defaults to `'unknown'` until a card brand is recognized. |
 
 ### FieldError
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds Elements documentation for new `cardBrand` onChange event property when using a `CardElement`.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

<img width="1499" alt="image" src="https://user-images.githubusercontent.com/43392371/169538895-606c3c8b-6479-4725-960b-a766407ece20.png">

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/43392371/169547170-5b3fb2dd-51a9-4283-9bb4-5a8d5f5f43c3.png">

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [X] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
